### PR TITLE
Use updated Debian package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.6.1
+FROM circleci/python:3.6-stretch
 ADD requirements.txt .
 RUN sudo apt-get update
 RUN sudo apt-get install shellcheck


### PR DESCRIPTION
The older CircleCI image uses Jessie which is EOL'd.