### PR TITLE
Remove poetry version pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN sudo pip install -r requirements.txt
 # Circle comes with a pip installed version of poetry that doesn't play nice with preview versions we need
 # We will remove it and reinstall it with the "proper" install script that vendors its dependencies
 # The default home for poetry doesn't get added to the circle users path. Overridding POETRY_HOME
-ARG POETRY_VERSION="1.0.0b4"
 ENV POETRY_HOME="/home/circleci/.local"
 ADD get-poetry.py .
 RUN sudo pip uninstall poetry cleo -y
-RUN python get-poetry.py --preview -y --version ${POETRY_VERSION}
+RUN python get-poetry.py -y


### PR DESCRIPTION
Version 1.0 is now out and we no longer need to ping to specific prerelease versions. 